### PR TITLE
Modernize “No Bookmarks” placeholder on iOS 17 and later

### DIFF
--- a/Font Booklet/Main View.swift
+++ b/Font Booklet/Main View.swift
@@ -45,19 +45,22 @@ struct MainView: View {
 			}
 			.overlay {
 				if visibleFamilies.isEmpty {
-					// Xcode 15: Replace this with `ContentUnavailableView`.
-					VStack {
-						Image(systemName: "bookmark.fill")
-							.foregroundStyle(.secondary)
-							.font(.largeTitle)
-						Text(InterfaceText.noBookmarks)
-							.font(.title)
-						Text(InterfaceText._howToBookmark)
-							.foregroundStyle(.secondary)
+					if #available(iOS 17, *) {
+						ContentUnavailableView(InterfaceText.noBookmarks, systemImage: "bookmark.fill", description: Text(InterfaceText._howToBookmark))
+					} else {
+						VStack {
+							Image(systemName: "bookmark.fill")
+								.foregroundStyle(.secondary)
+								.font(.largeTitle)
+							Text(InterfaceText.noBookmarks)
+								.font(.title)
+							Text(InterfaceText._howToBookmark)
+								.foregroundStyle(.secondary)
+						}
+						.multilineTextAlignment(.center)
+						.padding()
+						.accessibilityElement(children: .combine)
 					}
-					.multilineTextAlignment(.center)
-					.padding()
-					.accessibilityElement(children: .combine)
 				}
 			}
 			.listStyle(.plain)


### PR DESCRIPTION
Adopted [`ContentUnavailableView`](https://developer.apple.com/documentation/swiftui/contentunavailableview) when available, for consistency with other apps.

1. Font Booklet, old (still used on iOS versions below 17)
2. Font Booklet, new (on iOS 17.0 and later)
3. Messages, iOS 17.5

![Image](https://github.com/LoudSoundDreams/Font_Booklet/assets/140438172/54b207ce-6582-43c0-a473-da3bd2972c31)