### PR TITLE
Add Search

### DIFF
--- a/Font Booklet/Constants.swift
+++ b/Font Booklet/Constants.swift
@@ -31,6 +31,8 @@ enum InterfaceText {
 	static let unbookmark = "Unbookmark"
 	static let clearAllBookmarks = "Clear All Bookmarks"
 	
+	static let noResults = "No Results"
+	
 	static let editSampleText_axLabel = "Edit sample text"
 	static let sampleText = "Sample Text"
 	static let pangram_exclamationMark = "Pangram!"


### PR DESCRIPTION
Plays nice with the “filter to bookmarks” button. The “No Bookmarks” placeholder takes precedence over the “No Results” placeholder when applicable.

Tested on iPhone (iOS 17.5.1) and iPad Simulator (iOS 16.4).

![1](https://github.com/LoudSoundDreams/Font_Booklet/assets/140438172/5d399246-12c7-4740-8584-5e503f42de45)
![2](https://github.com/LoudSoundDreams/Font_Booklet/assets/140438172/06dc0c5c-ffc4-49b5-a064-a1a844cdb77d)