### PR TITLE
Replace Pangram button with Dice button

### DIFF
--- a/Font Booklet/Constants.swift
+++ b/Font Booklet/Constants.swift
@@ -33,7 +33,6 @@ enum InterfaceText {
 	
 	static let noResults = "No Results"
 	
-	static let editSampleText_axLabel = "Edit sample text"
-	static let sampleText = "Sample Text"
+	static let editText = "Edit Text"
 	static let pangram_exclamationMark = "Pangram!"
 }

--- a/Font Booklet/Knowledge.swift
+++ b/Font Booklet/Knowledge.swift
@@ -11,8 +11,8 @@ enum Pangram {
 		}
 		return result
 	}
-	static func symbolName(ifKnown sample: String) -> String? {
-		return mysteryBag[sample]
+	static func symbolName(forText: String) -> String {
+		return mysteryBag[forText] ?? "dice"
 	}
 	private static let mysteryBag: [String: String] = [
 		// Alphabetized, except with fallback last.

--- a/Font Booklet/Knowledge.swift
+++ b/Font Booklet/Knowledge.swift
@@ -4,7 +4,14 @@ enum Pangram {
 	static let standard = "The quick brown fox jumps over the lazy dog."
 	// Not “jumped”.
 	
-	static let mysteryBag: [String] = [
+	static func random(otherThan: String) -> String {
+		var result = otherThan
+		while result == otherThan {
+			result = mysteryBag.randomElement()!
+		}
+		return result
+	}
+	private static let mysteryBag: [String] = [
 		"Amazingly few discotheques provide jukeboxes.",
 		// Fewest words
 		

--- a/Font Booklet/Knowledge.swift
+++ b/Font Booklet/Knowledge.swift
@@ -7,23 +7,29 @@ enum Pangram {
 	static func random(otherThan: String) -> String {
 		var result = otherThan
 		while result == otherThan {
-			result = mysteryBag.randomElement()!
+			result = mysteryBag.keys.randomElement()!
 		}
 		return result
 	}
-	private static let mysteryBag: [String] = [
-		"Amazingly few discotheques provide jukeboxes.",
+	static func symbolName(ifKnown sample: String) -> String? {
+		return mysteryBag[sample]
+	}
+	private static let mysteryBag: [String: String] = [
+		// Alphabetized, except with fallback last.
+		
+		"Amazingly few discotheques provide jukeboxes.": "die.face.1",
 		// Fewest words
 		
-		"Farmer Jack realized the big yellow quilt was expensive.",
+		"Farmer Jack realized the big yellow quilt was expensive.": "die.face.2",
 		// Close to one that aired on “Jeopardy!”
 		
-		"Grumpy wizards make toxic brew for the jovial queen.",
-		"Pack my box with five dozen liquor jugs.",
-		"Quick-blowing zephyrs vex daft Jim.",
+		"Pack my box with five dozen liquor jugs.": "die.face.3",
+		"Quick-blowing zephyrs vex daft Jim.": "die.face.4",
 		
-		"Watch “Jeopardy!”, Alex Trebek’s fun TV quiz game.",
+		"Watch “Jeopardy!”, Alex Trebek’s fun TV quiz game.": "die.face.5",
 		// Includes quotation marks. Keep them curly! https://practicaltypography.com/straight-and-curly-quotes.html
+		
+		Self.standard: "die.face.6"
 	]
 }
 

--- a/Font Booklet/Main View.swift
+++ b/Font Booklet/Main View.swift
@@ -93,24 +93,15 @@ struct MainView: View {
 				ToolbarItem(placement: .bottomBar) {
 					Button(
 						InterfaceText.pangram_exclamationMark,
-						systemImage: {
-							switch d6 {
-								case 1: return "die.face.1"
-								case 2: return "die.face.2"
-								case 4: return "die.face.4"
-								case 5: return "die.face.5"
-								case 6: return "die.face.6"
-								default: return "die.face.3" // Most recognizable. If we weren’t doing this little joke, we’d use this icon every time. (Second–most recognizable is 6.)
-							}
-						}()
+						systemImage: Pangram.symbolName(
+							ifKnown: (
+								sample == ""
+								? Pangram.standard // So that if the user clears the text, we don’t momentarily show the default symbol.
+								: sample
+							)
+						) ?? "dice"
 					) {
 						sample = Pangram.random(otherThan: sample)
-						
-						var newD6 = d6
-						while newD6 == d6 {
-							newD6 = .random(in: 1...6)
-						}
-						d6 = newD6
 					}
 				}
 				ToolbarItem(placement: .bottomBar) { Spacer() }
@@ -145,7 +136,6 @@ struct MainView: View {
 	@State private var searchQuery: String = ""
 	@State private var filteringToBookmarked = false
 	@State private var clearBookmarksConfirmationIsPresented = false
-	@State private var d6: Int = .random(in: 1...6)
 	@State private var editingSample = false
 	
 	private var filterButton: some View {
@@ -165,7 +155,7 @@ struct MainView: View {
 	}
 	private var editSampleDoneButton: some View {
 		Button(InterfaceText.done) {
-			if sample.isEmpty {
+			if sample == "" {
 				sample = Pangram.standard
 			}
 		}.keyboardShortcut(.defaultAction)

--- a/Font Booklet/Main View.swift
+++ b/Font Booklet/Main View.swift
@@ -91,16 +91,39 @@ struct MainView: View {
 				ToolbarItem(placement: .bottomBar) { filterButton }
 				ToolbarItem(placement: .bottomBar) { Spacer() }
 				ToolbarItem(placement: .bottomBar) {
+					Button(
+						InterfaceText.pangram_exclamationMark,
+						systemImage: {
+							switch d6 {
+								case 1: return "die.face.1"
+								case 2: return "die.face.2"
+								case 4: return "die.face.4"
+								case 5: return "die.face.5"
+								case 6: return "die.face.6"
+								default: return "die.face.3" // Most recognizable. If we weren’t doing this little joke, we’d use this icon every time. (Second–most recognizable is 6.)
+							}
+						}()
+					) {
+						sample = Pangram.random(otherThan: sample)
+						
+						var newD6 = d6
+						while newD6 == d6 {
+							newD6 = .random(in: 1...6)
+						}
+						d6 = newD6
+					}
+				}
+				ToolbarItem(placement: .bottomBar) { Spacer() }
+				ToolbarItem(placement: .bottomBar) {
 					Button {
 						editingSample = true
 					} label: {
 						Image(systemName: "character.cursor.ibeam")
 					}
-					.accessibilityLabel(InterfaceText.editSampleText_axLabel)
+					.accessibilityLabel(InterfaceText.editText)
 					.disabled(visibleFamilies.isEmpty)
-					.alert(InterfaceText.sampleText, isPresented: $editingSample) {
+					.alert(InterfaceText.editText, isPresented: $editingSample) {
 						editSampleTextField
-						editSamplePangramButton
 						editSampleDoneButton
 					}
 				}
@@ -122,6 +145,7 @@ struct MainView: View {
 	@State private var searchQuery: String = ""
 	@State private var filteringToBookmarked = false
 	@State private var clearBookmarksConfirmationIsPresented = false
+	@State private var d6: Int = .random(in: 1...6)
 	@State private var editingSample = false
 	
 	private var filterButton: some View {
@@ -137,15 +161,6 @@ struct MainView: View {
 	private var editSampleTextField: some View {
 		TextField(text: $sample, prompt: Text(Pangram.standard)) {
 			let _ = UITextField.appearance().clearButtonMode = .whileEditing
-		}
-	}
-	private var editSamplePangramButton: some View {
-		Button(InterfaceText.pangram_exclamationMark) {
-			var newSample = sample
-			while newSample == sample {
-				newSample = Pangram.mysteryBag.randomElement()!
-			}
-			sample = newSample
 		}
 	}
 	private var editSampleDoneButton: some View {

--- a/Font Booklet/Main View.swift
+++ b/Font Booklet/Main View.swift
@@ -94,12 +94,11 @@ struct MainView: View {
 					Button { // `Button(_:systemImage:action:)` is simpler, but as of iOS 17.5.1, it inexplicably over-applies Increase Contrast.
 						sample = Pangram.random(otherThan: sample)
 					} label: {
-						Image(systemName: Pangram.symbolName(
-							ifKnown: (
-								sample == ""
-								? Pangram.standard // So that if the user clears the text, we don’t momentarily show the default symbol.
-								: sample
-							)) ?? "dice")
+						Image(systemName: Pangram.symbolName(forText: (
+							sample == ""
+							? Pangram.standard // So that if the user clears the text, we don’t momentarily show the default symbol.
+							: sample
+						)))
 						.animation(nil, value: sample)
 						.accessibilityLabel(InterfaceText.pangram_exclamationMark)
 					}

--- a/Font Booklet/Main View.swift
+++ b/Font Booklet/Main View.swift
@@ -91,17 +91,17 @@ struct MainView: View {
 				ToolbarItem(placement: .bottomBar) { filterButton }
 				ToolbarItem(placement: .bottomBar) { Spacer() }
 				ToolbarItem(placement: .bottomBar) {
-					Button(
-						InterfaceText.pangram_exclamationMark,
-						systemImage: Pangram.symbolName(
+					Button { // `Button(_:systemImage:action:)` is simpler, but as of iOS 17.5.1, it inexplicably over-applies Increase Contrast.
+						sample = Pangram.random(otherThan: sample)
+					} label: {
+						Image(systemName: Pangram.symbolName(
 							ifKnown: (
 								sample == ""
 								? Pangram.standard // So that if the user clears the text, we don’t momentarily show the default symbol.
 								: sample
-							)
-						) ?? "dice"
-					) {
-						sample = Pangram.random(otherThan: sample)
+							)) ?? "dice")
+						.animation(nil, value: sample)
+						.accessibilityLabel(InterfaceText.pangram_exclamationMark)
 					}
 				}
 				ToolbarItem(placement: .bottomBar) { Spacer() }

--- a/Font Booklet/Shared Views.swift
+++ b/Font Booklet/Shared Views.swift
@@ -19,7 +19,7 @@ struct SampleView: View {
 						? "\(InterfaceText.bookmarked), \(label)"
 						: label
 					)
-				Text(sampleText.isEmpty ? Pangram.standard : sampleText)
+				Text(sampleText == "" ? Pangram.standard : sampleText)
 					.font(.custom(memberName, size: .eight * 4))
 			}
 			Spacer()


### PR DESCRIPTION
Increases funness by around 500%.

- Top: before
- Middle: after
- Bottom: various dice for various text samples

![Image](https://github.com/LoudSoundDreams/Font_Booklet/assets/140438172/776d5501-31e4-4b2f-b147-2e6f594ad4f8)
![Dice](https://github.com/LoudSoundDreams/Font_Booklet/assets/140438172/ac3b8d59-9747-485f-a9df-db0fa3af2131)