### PR TITLE
Rearrange buttons and keep them visible

### DIFF
--- a/Font Booklet/Main View.swift
+++ b/Font Booklet/Main View.swift
@@ -69,7 +69,14 @@ struct MainView: View {
 			.listStyle(.plain)
 			.navigationTitle(InterfaceText.fonts)
 			.navigationBarTitleDisplayMode(.inline)
-			.searchable(text: $query, placement: .navigationBarDrawer(displayMode: .always)) // I’d like to use `searchPresentationToolbarBehavior(.avoidHidingContent)`, but as of iOS 17.5.1, if the search field has contents, presenting the “Clear All Bookmarks” action sheet inexplicably opens the keyboard.
+			.searchable(text: $query, placement: .navigationBarDrawer(displayMode: .always))
+			.modifiedBy {
+				if #available(iOS 17.1, *) {
+					$0.searchPresentationToolbarBehavior(.avoidHidingContent) // As of iOS 17.5.1, if the search field has contents, presenting the “Clear All Bookmarks” action sheet inexplicably opens the keyboard.
+				} else {
+					$0
+				}
+			}
 			.toolbar {
 				ToolbarItem(placement: .topBarLeading) {
 					Button {
@@ -180,6 +187,10 @@ private extension View {
 				}.tint(.red)
 			}
 		}
+	}
+	
+	func modifiedBy(@ViewBuilder _ modifier: (Self) -> some View) -> some View {
+		modifier(self)
 	}
 }
 

--- a/Font Booklet/Main View.swift
+++ b/Font Booklet/Main View.swift
@@ -86,10 +86,9 @@ struct MainView: View {
 						Button(InterfaceText.cancel, role: .cancel) {}
 					}
 				}
+				ToolbarItem(placement: .topBarTrailing) { filterButton }
 			}
 			.toolbar {
-				ToolbarItem(placement: .bottomBar) { filterButton }
-				ToolbarItem(placement: .bottomBar) { Spacer() }
 				ToolbarItem(placement: .bottomBar) {
 					Button { // `Button(_:systemImage:action:)` is simpler, but as of iOS 17.5.1, it inexplicably over-applies Increase Contrast.
 						sample = Pangram.random(otherThan: sample)


### PR DESCRIPTION
Screw it, this is way nicer to use. List-wide controls (Clear, Filter, Search) are now at the top, separated from the per-row controls (Dice, Edit Text); and list-wide controls stay visible.

That’s more important than preventing the bug when you’ve typed something into the search field and tap Clear.

- Top: before
- Bottom: after

![Image](https://github.com/LoudSoundDreams/Font_Booklet/assets/140438172/0c775578-2e78-4aab-9264-ed003852a56c)